### PR TITLE
Removing mail domain during UniPi website login

### DIFF
--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -90,7 +90,7 @@ async function DoInteractiveLogin(url: string, username?: string): Promise<Sessi
         
         //********************* HANDLING UNIPI PAGE
         await page.waitForSelector('input[type="text"]');
-        await page.type('input[type="text"]', unipi_usr);
+        await page.type('input[type="text"]', unipi_usr.replace("@studenti.unipi.it",""));
         await page.type('input[type="password"]', unipi_psw);
         await page.click('button[type="submit"]');
         


### PR DESCRIPTION
I found out that login using mail address doesn't work. UniPi website seems to require only username