### PR TITLE
Input credentials from console

### DIFF
--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -113,7 +113,9 @@ async function DoInteractiveLogin(url: string, username?: string): Promise<Sessi
     const videoId = url.split('/').pop() ?? process.exit(ERROR_CODE.INVALID_VIDEO_ID);
     
     //*********************************************  ADDING UNIPI CREDENTIALS
-    const { unipi_usr, unipi_psw } = await getUnipiCredentials();	
+    const credentials = await getUnipiCredentials();
+    let unipi_usr:string = credentials.unipi_usr;
+    let unipi_psw:string = credentials.unipi_psw;
 	
     if (!username){
     	username = "no_need_to_change@studenti.unipi.it"	


### PR DESCRIPTION
I this pull request if the file `credentials.txt` doesn't exist, the user can input the username and password via the console.
After that the user can also choose to save the credentials in the `credentials.txt` file:

![Screenshot from 2020-10-19 21-04-06](https://user-images.githubusercontent.com/6524326/96500117-acc0d600-124e-11eb-89b5-23342094b0c8.png)